### PR TITLE
Support passing of va_list

### DIFF
--- a/include/slf4ec/log.h
+++ b/include/slf4ec/log.h
@@ -4,7 +4,7 @@
  * Simplified logging API
  *
  * @author Jérémie Faucher-Goulet
- * 
+ *
  * @copyright Trilliant Inc. © 2015 - http://www.trilliantinc.com
  *
  * @License
@@ -71,6 +71,18 @@ extern "C" {
     TOKEN_PASTE(_logOff, IS_EXTRA(__VA_ARGS__)(logCategory, __VA_ARGS__))
 
 /**
+ * A version of logOff() that is passed a set of arguments as a va_list.
+ *
+ * @param [in] logCategory ::LogCategory to log against
+ * @param [in] fmt  The message string, including any format specifiers which will be replaced by the values specified in the argument list that follows.
+ * @param [in] valist  The argument list
+ * @retval ::LOG_OK Logged successfully.
+ * @retval ::LOG_NOT_INITIALIZED ::initLogger must be called prior to logging.
+ */
+#define vlogOff(logCategory, fmt, valist) \
+    _vlogOff(logCategory, fmt, valist)
+
+/**
  * Logs fatal information. See ::LEVEL_FATAL
  *
  * @param [in] logCategory ::LogCategory to log against
@@ -83,6 +95,18 @@ extern "C" {
  */
 #define logFatal(logCategory, ...) \
     TOKEN_PASTE(_logFatal, IS_EXTRA(__VA_ARGS__)(logCategory, __VA_ARGS__))
+
+/**
+ * A version of logFatal() that is passed a set of arguments as a va_list.
+ *
+ * @param [in] logCategory ::LogCategory to log against
+ * @param [in] fmt  The message string, including any format specifiers which will be replaced by the values specified in the argument list that follows.
+ * @param [in] valist  The argument list
+ * @retval ::LOG_OK Logged successfully.
+ * @retval ::LOG_NOT_INITIALIZED ::initLogger must be called prior to logging.
+ */
+#define vlogFatal(logCategory, fmt, valist) \
+    _vlogFatal(logCategory, fmt, valist)
 
 /**
  * Logs error information. See ::LEVEL_ERROR
@@ -99,6 +123,18 @@ extern "C" {
     TOKEN_PASTE(_logError, IS_EXTRA(__VA_ARGS__)(logCategory, __VA_ARGS__))
 
 /**
+ * A version of logError() that is passed a set of arguments as a va_list.
+ *
+ * @param [in] logCategory ::LogCategory to log against
+ * @param [in] fmt  The message string, including any format specifiers which will be replaced by the values specified in the argument list that follows.
+ * @param [in] valist  The argument list
+ * @retval ::LOG_OK Logged successfully.
+ * @retval ::LOG_NOT_INITIALIZED ::initLogger must be called prior to logging.
+ */
+#define vlogError(logCategory, fmt, valist) \
+    _vlogError(logCategory, fmt, valist)
+
+/**
  * Logs warning information. See ::LEVEL_WARN
  *
  * @param [in] logCategory ::LogCategory to log against
@@ -111,6 +147,18 @@ extern "C" {
  */
 #define logWarn(logCategory, ...) \
     TOKEN_PASTE(_logWarn, IS_EXTRA(__VA_ARGS__)(logCategory, __VA_ARGS__))
+
+/**
+ * A version of logWarn() that is passed a set of arguments as a va_list.
+ *
+ * @param [in] logCategory ::LogCategory to log against
+ * @param [in] fmt  The message string, including any format specifiers which will be replaced by the values specified in the argument list that follows.
+ * @param [in] valist  The argument list
+ * @retval ::LOG_OK Logged successfully.
+ * @retval ::LOG_NOT_INITIALIZED ::initLogger must be called prior to logging.
+ */
+#define vlogWarn(logCategory, fmt, valist) \
+    _vlogWarn(logCategory, fmt, valist)
 
 /**
  * Logs information. See ::LEVEL_INFO
@@ -127,6 +175,18 @@ extern "C" {
     TOKEN_PASTE(_logInfo, IS_EXTRA(__VA_ARGS__)(logCategory, __VA_ARGS__))
 
 /**
+ * A version of logInfo() that is passed a set of arguments as a va_list.
+ *
+ * @param [in] logCategory ::LogCategory to log against
+ * @param [in] fmt  The message string, including any format specifiers which will be replaced by the values specified in the argument list that follows.
+ * @param [in] valist  The argument list
+ * @retval ::LOG_OK Logged successfully.
+ * @retval ::LOG_NOT_INITIALIZED ::initLogger must be called prior to logging.
+ */
+#define vlogInfo(logCategory, fmt, valist) \
+    _vlogInfo(logCategory, fmt, valist)
+
+/**
  * Logs debug information. See ::LEVEL_DEBUG
  *
  * @param [in] logCategory ::LogCategory to log against
@@ -139,6 +199,18 @@ extern "C" {
  */
 #define logDebug(logCategory, ...) \
     TOKEN_PASTE(_logDebug, IS_EXTRA(__VA_ARGS__)(logCategory, __VA_ARGS__))
+
+/**
+ * A version of logDebug() that is passed a set of arguments as a va_list.
+ *
+ * @param [in] logCategory ::LogCategory to log against
+ * @param [in] fmt  The message string, including any format specifiers which will be replaced by the values specified in the argument list that follows.
+ * @param [in] valist  The argument list
+ * @retval ::LOG_OK Logged successfully.
+ * @retval ::LOG_NOT_INITIALIZED ::initLogger must be called prior to logging.
+ */
+#define vlogDebug(logCategory, fmt, valist) \
+    _vlogDebug(logCategory, fmt, valist)
 
 /**
  * Logs trace information. See ::LEVEL_TRACE
@@ -155,6 +227,18 @@ extern "C" {
     TOKEN_PASTE(_logTrace, IS_EXTRA(__VA_ARGS__)(logCategory, __VA_ARGS__))
 
 /**
+ * A version of logTrace() that is passed a set of arguments as a va_list.
+ *
+ * @param [in] logCategory ::LogCategory to log against
+ * @param [in] fmt  The message string, including any format specifiers which will be replaced by the values specified in the argument list that follows.
+ * @param [in] valist  The argument list
+ * @retval ::LOG_OK Logged successfully.
+ * @retval ::LOG_NOT_INITIALIZED ::initLogger must be called prior to logging.
+ */
+#define vlogTrace(logCategory, fmt, valist) \
+    _vlogTrace(logCategory, fmt, valist)
+
+/**
  * Logging to be used temporarily during development. See ::LEVEL_TEST
  *
  * @param [in] logCategory ::LogCategory to log against
@@ -167,6 +251,18 @@ extern "C" {
  */
 #define logTest(logCategory, ...) \
     TOKEN_PASTE(_logTest, IS_EXTRA(__VA_ARGS__)(logCategory, __VA_ARGS__))
+
+/**
+ * A version of logTest() that is passed a set of arguments as a va_list.
+ *
+ * @param [in] logCategory ::LogCategory to log against
+ * @param [in] fmt  The message string, including any format specifiers which will be replaced by the values specified in the argument list that follows.
+ * @param [in] valist  The argument list
+ * @retval ::LOG_OK Logged successfully.
+ * @retval ::LOG_NOT_INITIALIZED ::initLogger must be called prior to logging.
+ */
+#define vlogTest(logCategory, fmt, valist) \
+    _vlogTest(logCategory, fmt, valist)
 
 /**
  * Checks if logging is active for the specified @p logCategory and @p logLevel.

--- a/include/slf4ec/slf4ec.h
+++ b/include/slf4ec/slf4ec.h
@@ -4,7 +4,7 @@
  * Full interface for SLF4EC
  *
  * @author Jérémie Faucher-Goulet
- * 
+ *
  * @copyright Trilliant Inc. © 2015 - http://www.trilliantinc.com
  *
  * @License
@@ -106,12 +106,14 @@ IS_EXTRA_(                                                                      
  */
 LogResult nfLog0(const LogCategory* category, const uint8_t level, const char* msg);
 LogResult nfLog1(const LogCategory* category, const uint8_t level, const char* formatStr, ...);
+LogResult nfLogv(const LogCategory* category, const uint8_t level, const char* formatStr, va_list vaList);
 #else
 /**
  * Private function called by macros to log with location information.
  */
 LogResult yfLog0(const char* file, const uint32_t line, const char* function, const LogCategory* category, const uint8_t level, const char* msg);
 LogResult yfLog1(const char* file, const uint32_t line, const char* function, const LogCategory* category, const uint8_t level, const char* formatStr, ...);
+LogResult yfLogv(const char* file, const uint32_t line, const char* function, const LogCategory* category, const uint8_t level, const char* formatStr, va_list vaList);
 #endif
 
 /**
@@ -217,11 +219,15 @@ LogResult noLog();
     yfLog0(__FILE__, __LINE__, FUNCTION, &logCategory, level, __VA_ARGS__)
 #define _log1(logCategory, level, ...) \
     yfLog1(__FILE__, __LINE__, FUNCTION, &logCategory, level, __VA_ARGS__)
+#define _logv(logCategory, level, fmt, vaList) \
+    yfLogv(__FILE__, __LINE__, FUNCTION, &logCategory, level, fmt, vaList)
 #else
 #define _log0(logCategory, level, ...) \
     nfLog0(&logCategory, level, __VA_ARGS__)
 #define _log1(logCategory, level, ...) \
     nfLog1(&logCategory, level, __VA_ARGS__)
+#define _logv(logCategory, level, fmt, vaList) \
+    nfLogv(&logCategory, level, fmt, vaList)
 #endif
 
 #ifdef __cplusplus

--- a/include/slf4ec/slf4ec.h
+++ b/include/slf4ec/slf4ec.h
@@ -130,17 +130,23 @@ LogResult noLog();
     noLog()
 #define _logOff1(logCategory, ...) \
     noLog()
+#define _vlogOff(logCategory, ...) \
+    noLog()
 
 #if COMPILED_LOG_LEVEL >= LEVEL_FATAL
 #define _logFatal0(logCategory, ...) \
     _log0(logCategory, LEVEL_FATAL, __VA_ARGS__)
 #define _logFatal1(logCategory, ...) \
     _log1(logCategory, LEVEL_FATAL, __VA_ARGS__)
+#define _vlogFatal(logCategory, fmt, valist) \
+    _logv(logCategory, LEVEL_FATAL, fmt, valist)
 #else
 #define _logFatal0(logCategory, ...) \
     noLog()
 #define _logFatal1(logCategory, ...) \
     noLog()
+#define _vlogFatal(logCategory, fmt, valist) \
+    nolog()
 #endif
 
 #if COMPILED_LOG_LEVEL >= LEVEL_ERROR
@@ -148,11 +154,15 @@ LogResult noLog();
     _log0(logCategory, LEVEL_ERROR, __VA_ARGS__)
 #define _logError1(logCategory, ...) \
     _log1(logCategory, LEVEL_ERROR, __VA_ARGS__)
+#define _vlogError(logCategory, fmt, valist) \
+    _logv(logCategory, LEVEL_ERROR, fmt, valist)
 #else
 #define _logError0(logCategory, ...) \
     noLog()
 #define _logError1(logCategory, ...) \
     noLog()
+#define _vlogError(logCategory, fmt, valist) \
+    nolog()
 #endif
 
 #if COMPILED_LOG_LEVEL >= LEVEL_WARN
@@ -160,11 +170,15 @@ LogResult noLog();
     _log0(logCategory, LEVEL_WARN, __VA_ARGS__)
 #define _logWarn1(logCategory, ...) \
     _log1(logCategory, LEVEL_WARN, __VA_ARGS__)
+#define _vlogWarn(logCategory, fmt, valist) \
+    _logv(logCategory, LEVEL_WARN, fmt, valist)
 #else
 #define _logWarn0(logCategory, ...) \
     noLog()
 #define _logWarn1(logCategory, ...) \
     noLog()
+#define _vlogWarn(logCategory, fmt, valist) \
+    nolog()
 #endif
 
 #if COMPILED_LOG_LEVEL >= LEVEL_INFO
@@ -172,11 +186,15 @@ LogResult noLog();
     _log0(logCategory, LEVEL_INFO, __VA_ARGS__)
 #define _logInfo1(logCategory, ...) \
     _log1(logCategory, LEVEL_INFO, __VA_ARGS__)
+#define _vlogInfo(logCategory, fmt, valist) \
+    _logv(logCategory, LEVEL_INFO, fmt, valist)
 #else
 #define _logInfo0(logCategory, ...) \
     noLog()
 #define _logInfo1(logCategory, ...) \
     noLog()
+#define _vlogInfo(logCategory, fmt, valist) \
+    nolog()
 #endif
 
 #if COMPILED_LOG_LEVEL >= LEVEL_DEBUG
@@ -184,11 +202,15 @@ LogResult noLog();
     _log0(logCategory, LEVEL_DEBUG, __VA_ARGS__)
 #define _logDebug1(logCategory, ...) \
     _log1(logCategory, LEVEL_DEBUG, __VA_ARGS__)
+#define _vlogDebug(logCategory, fmt, valist) \
+    _logv(logCategory, LEVEL_DEBUG, fmt, valist)
 #else
 #define _logDebug0(logCategory, ...) \
     noLog()
 #define _logDebug1(logCategory, ...) \
     noLog()
+#define _vlogDebug(logCategory, fmt, valist) \
+    nolog()
 #endif
 
 #if COMPILED_LOG_LEVEL >= LEVEL_TRACE
@@ -196,17 +218,23 @@ LogResult noLog();
     _log0(logCategory, LEVEL_TRACE, __VA_ARGS__)
 #define _logTrace1(logCategory, ...) \
     _log1(logCategory, LEVEL_TRACE, __VA_ARGS__)
+#define _vlogTrace(logCategory, fmt, valist) \
+    _logv(logCategory, LEVEL_TRACE, fmt, valist)
 #else
 #define _logTrace0(logCategory, ...) \
     noLog()
 #define _logTrace1(logCategory, ...) \
     noLog()
+#define _vlogTrace(logCategory, fmt, valist) \
+    nolog()
 #endif
 
 #define _logTest0(logCategory, ...) \
     _log0(logCategory, LEVEL_TEST, __VA_ARGS__)
 #define _logTest1(logCategory, ...) \
     _log1(logCategory, LEVEL_TEST, __VA_ARGS__)
+#define _vlogTest(logCategory, fmt, valist) \
+    _logv(logCategory, LEVEL_TEST, fmt, valist)
 
 /*
  ************************************************************


### PR DESCRIPTION
To use SLF4EC with some libraries that have their own logging API, support for passing an explicit va_list instead of an implied variable list (using ...) is needed. This commit adds a new function (_logv) to allow for just that. 